### PR TITLE
BUG Fix issue with VersionedFiles crashing mid-folder-rename due to outdated has_one cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,21 +9,14 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
 
 env:
-  - DB=MYSQL CORE_RELEASE=3.2
+  - DB=MYSQL CORE_RELEASE=3.5
 
 matrix:
   include:
     - php: 5.6
       env: DB=MYSQL CORE_RELEASE=3
-    - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.1
-    - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=3.2
-  allow_failures:
-    - php: 7.0
 
 before_script:
   - composer self-update || true

--- a/code/FileVersion.php
+++ b/code/FileVersion.php
@@ -111,9 +111,11 @@ class FileVersion extends DataObject
      */
     protected function saveCurrentVersion()
     {
-        if ($this->File()->ParentID) {
+        // Ensure we re-fetch fresh record from database (in case it was recently renamed / moved)
+        $file = File::get()->byID($this->FileID);
+        if ($file->ParentID) {
             $base = Controller::join_links(
-                $this->File()->Parent()->getFullPath(),
+                $file->Parent()->getFullPath(),
                 self::VERSION_FOLDER,
                 $this->FileID
             );
@@ -128,15 +130,15 @@ class FileVersion extends DataObject
 
         Filesystem::makeFolder($base);
 
-        $extension = $this->File()->getExtension();
-        $basename  = basename($this->File()->Name, $extension);
+        $extension = $file->getExtension();
+        $basename  = basename($file->Name, $extension);
         $version   = $this->VersionNumber;
 
         $cachedPath = Controller::join_links(
             $base, "{$basename}$version.$extension"
         );
 
-        if (!copy($this->File()->getFullPath(), $cachedPath)) {
+        if (!copy($file->getFullPath(), $cachedPath)) {
             throw new Exception(
                 "Unable to save version #$version of file #$this->FileID."
             );


### PR DESCRIPTION
Fixes #43

Without this fix, FolderTest in core (framework) will crash due to trying to perform a file copy() on the outdated path (which doesn't exist) when creating a new FileVersion record.

This behaviour forces a re-requery of the newly updated record from the database.